### PR TITLE
add type for user and create default user

### DIFF
--- a/app/Controllers/Http/UserController.js
+++ b/app/Controllers/Http/UserController.js
@@ -27,14 +27,21 @@ class UserController {
 
     const {
       permissions,
-      roles,
       // token,
       password,
       username,
       email
     } = subscription;
     const hashPass = await Hash.make(password);
-    const user = await User.create({ username, email, password: hashPass });
+    const user = await User.create({
+      username,
+      email,
+      type: 'guest',
+      password: hashPass
+    });
+
+    // default role for user
+    const roles = [];
 
     if (roles) await user.roles().attach(roles);
     if (permissions) await user.permissions().attach(permissions);

--- a/database/migrations/1503250034279_user.js
+++ b/database/migrations/1503250034279_user.js
@@ -10,6 +10,7 @@ class UserSchema extends Schema {
         .notNullable()
         .unique();
       table.string('password', 60).notNullable();
+      table.string('type', 60);
       table.string('email', 254).notNullable();
       table.timestamps();
     });

--- a/database/migrations/1562000753274_create_default_user_schema.js
+++ b/database/migrations/1562000753274_create_default_user_schema.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+const Database = use('Database');
+const Hash = use('Hash');
+// const { User } = use('App/Models');
+
+class CreateDefaultUserSchema extends Schema {
+  async up() {
+    const password = await Hash.make('secret');
+    await Database.table('users').insert({
+      username: 'Admin',
+      email: 'admin@example.org',
+      type: 'Admin',
+      password,
+      created_at: Date.now(),
+      updated_at: Date.now()
+    });
+
+    // const user = await User.find(adminId);
+    // await user.loadMany(['roles', 'permissions']);
+    // user.roles().attach('Administrador');
+  }
+
+  async down() {
+    Database.select('id')
+      .from('users')
+      .where('email', 'admin@example.org')
+      .delete();
+  }
+}
+
+module.exports = CreateDefaultUserSchema;


### PR DESCRIPTION
não foi possivel utilizar relacionamentos para adicionar roles() na migration, então foi necessário criar uma coluna `type` para a tabela usuário.